### PR TITLE
Replacing overlaps in output by a single representation 

### DIFF
--- a/import.pl
+++ b/import.pl
@@ -319,6 +319,22 @@ if (@cyclic_contigs_with_blast_hits == 1)
 	    # delete spaces
 	    $chloroplast_seq =~ s/ //g;
 
+	    # find overlaps between start and end
+	    my $overlap_len = -1;
+	    for (my $i=0; $i<length($chloroplast_seq); $i++)
+	    {
+		if (substr($chloroplast_seq, 0, $i) eq substr($chloroplast_seq, $i*-1))
+		{
+		    $overlap_len = $i;
+		}
+	    }
+	    # if an overlap between start and end was found, remove it
+	    # from the start which should be the LSC
+	    if ($overlap_len != -1)
+	    {
+		my $overlap=substr($chloroplast_seq, 0, $overlap_len, "");
+	    }
+
 	    # add a newline
 	    $chloroplast_seq .= "\n";
 

--- a/import.pl
+++ b/import.pl
@@ -44,7 +44,7 @@ my $MINSEQLEN = 25000;
 my $MAXSEQLEN = 1000000;
 my $FACTOR4RESCUE = 10;
 
-use version 0.77; our $VERSION = version->declare("v0.4.0");
+use version 0.77; our $VERSION = version->declare("v0.5.0");
 
 our $ID = 'fcg';
 
@@ -298,11 +298,31 @@ if (@cyclic_contigs_with_blast_hits == 1)
 	# 1'-0 we need to find that edge
 	if ($c->has_edge($inverted_repeat, $lsc) || $c->has_edge($lsc, $inverted_repeat."'") || $c->has_edge($lsc."'", $inverted_repeat) || $c->has_edge($lsc."'", $inverted_repeat."'") )
 	{
-	    $chloroplast_seq .= get_orig_sequence_by_number($lsc).get_orig_sequence_by_number($inverted_repeat."'").get_orig_sequence_by_number($ssc).get_orig_sequence_by_number($inverted_repeat)."\n";
+	    $chloroplast_seq .= join(" ", get_orig_sequence_by_number($lsc),
+				          get_orig_sequence_by_number($inverted_repeat."'"),
+				          get_orig_sequence_by_number($ssc),
+				          get_orig_sequence_by_number($inverted_repeat)
+		);
 	} else {
-	    $chloroplast_seq .= get_orig_sequence_by_number($lsc).get_orig_sequence_by_number($inverted_repeat).get_orig_sequence_by_number($ssc).get_orig_sequence_by_number($inverted_repeat."'")."\n";
+	    $chloroplast_seq .= join(" ", get_orig_sequence_by_number($lsc),
+				          get_orig_sequence_by_number($inverted_repeat),
+				          get_orig_sequence_by_number($ssc),
+  	 			          get_orig_sequence_by_number($inverted_repeat."'")
+		);
 	}
 
+	if ($chloroplast_seq)
+	{
+	    # delete overlaps between nodes
+	    $chloroplast_seq =~ s/(\S+) \1/\1/g;
+
+	    # delete spaces
+	    $chloroplast_seq =~ s/ //g;
+
+	    # add a newline
+	    $chloroplast_seq .= "\n";
+
+	}
 	$L->info("Single circular chloroplast seems to be found");
 
     }

--- a/import.pl
+++ b/import.pl
@@ -290,7 +290,7 @@ if (@cyclic_contigs_with_blast_hits == 1)
 
 	$L->info(sprintf "The LSC is node number: %d and the SSC is node number: %d", $lsc, $ssc);
 
-	$chloroplast_seq = ">potential_chloroplast_sequence\n";
+	$chloroplast_seq = "";
 
 	# the order of lsc(0), inverted_repeat(1), ssc(2) is
 	# 0-1,1-2,2-1' or 0-1',1'-2,2-1 but the orientation of the ssc
@@ -314,7 +314,7 @@ if (@cyclic_contigs_with_blast_hits == 1)
 	if ($chloroplast_seq)
 	{
 	    # delete overlaps between nodes
-	    $chloroplast_seq =~ s/(\S+) \1/\1/g;
+	    $chloroplast_seq =~ s/(\S+) \1/$1/g;
 
 	    # delete spaces
 	    $chloroplast_seq =~ s/ //g;
@@ -333,10 +333,13 @@ if (@cyclic_contigs_with_blast_hits == 1)
 	    if ($overlap_len != -1)
 	    {
 		my $overlap=substr($chloroplast_seq, 0, $overlap_len, "");
+		$L->info(sprintf("An overlap between start/end detected and removed: length=%d; sequence='%s'", length($overlap_len), $overlap));
+	    } else {
+		$L->info("No overlap between start/end was detected or removed!");
 	    }
 
-	    # add a newline
-	    $chloroplast_seq .= "\n";
+	    # add a header and a newline after the sequence
+	    $chloroplast_seq = ">potential_chloroplast_sequence\n".$chloroplast_seq."\n";
 
 	}
 	$L->info("Single circular chloroplast seems to be found");

--- a/import.pl
+++ b/import.pl
@@ -44,7 +44,7 @@ my $MINSEQLEN = 25000;
 my $MAXSEQLEN = 1000000;
 my $FACTOR4RESCUE = 10;
 
-use version 0.77; our $VERSION = version->declare("v0.5.0");
+use version 0.77; our $VERSION = version->declare("v0.5.1");
 
 our $ID = 'fcg';
 

--- a/t/001_pass.t
+++ b/t/001_pass.t
@@ -12,7 +12,7 @@ use Test::Script::Run;
 # prepare run command
 my $input_file = "data/assembly_graph.fastg";
 my $output_file = "data/001.out";
-my $expected_output_md5 = "1a714bb1ce8505843b720c6f92efe41a";
+my $expected_output_md5 = "4110d147b3ca6b14e309a779c0c41c1f";
 
 my @arg = ("-i", $input_file, "-o", $output_file, '-b', 'data/cds.nr98.fa');
 

--- a/t/001_pass.t
+++ b/t/001_pass.t
@@ -12,7 +12,7 @@ use Test::Script::Run;
 # prepare run command
 my $input_file = "data/assembly_graph.fastg";
 my $output_file = "data/001.out";
-my $expected_output_md5 = "4110d147b3ca6b14e309a779c0c41c1f";
+my $expected_output_md5 = "9b1fe719966a7b398c4275c11b69244f";
 
 my @arg = ("-i", $input_file, "-o", $output_file, '-b', 'data/cds.nr98.fa');
 

--- a/t/005_real_example_pass.t
+++ b/t/005_real_example_pass.t
@@ -12,7 +12,7 @@ use Test::Script::Run;
 # prepare run command
 my $input_file = "data/SRR1503755_assembly_graph.fastg";
 my $output_file = "data/005.out";
-my $expected_output_md5 = "1b3f24c646bc76b47b32e99766691e8c";
+my $expected_output_md5 = "ef5cc06e330bde258f039cab86ca5f33";
 
 my @arg = ("-i", $input_file, "-o", $output_file, '-b', 'data/cds.nr98.fa');
 

--- a/t/005_real_example_pass.t
+++ b/t/005_real_example_pass.t
@@ -12,7 +12,7 @@ use Test::Script::Run;
 # prepare run command
 my $input_file = "data/SRR1503755_assembly_graph.fastg";
 my $output_file = "data/005.out";
-my $expected_output_md5 = "ef5cc06e330bde258f039cab86ca5f33";
+my $expected_output_md5 = "72d34a5b7cd49544d30e0e76e74ecf7f";
 
 my @arg = ("-i", $input_file, "-o", $output_file, '-b', 'data/cds.nr98.fa');
 


### PR DESCRIPTION
If a complete chloroplast was found, the returned sequence should be correct.

Therefore, I need to remove one representation of the overlap region between to contigs. Due to spades handling of fastg, those overlaps are part of both contigs and therefore will be duplicated.

Fixes #19
Fixes chloroExtractorTeam/chloroExtractor#101